### PR TITLE
Use bcrypt for password hashing

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -110,7 +110,7 @@ def signup_user(data: SignUp): # Renamed for clarity from just 'signup'
 def login_user(data: Login): # Renamed for clarity
     cur = conn.execute('SELECT id, password_hash FROM users WHERE email = ?', (data.email,))
     row = cur.fetchone()
-    if not row or auth.hash_password(data.password) != row[1]:
+    if not row or row[1] is None or not auth.verify_password(data.password, row[1]):
         raise HTTPException(status_code=401, detail='Invalid credentials')
     user_id = row[0]
     monitoring.log_event("login", {"user": user_id})

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pydantic
 httpx
 python-multipart
 python-jose
+passlib

--- a/src/auth.py
+++ b/src/auth.py
@@ -2,14 +2,23 @@
 
 from __future__ import annotations
 
-import hashlib
 import sqlite3
 from typing import Optional
 
+from passlib.context import CryptContext
+
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
 
 def hash_password(password: str) -> str:
-    """Return a SHA-256 hash of ``password``."""
-    return hashlib.sha256(password.encode("utf-8")).hexdigest()
+    """Return a secure hash of ``password`` using bcrypt."""
+    return pwd_context.hash(password)
+
+
+def verify_password(password: str, hashed: str) -> bool:
+    """Return ``True`` if ``password`` matches ``hashed``."""
+    return pwd_context.verify(password, hashed)
 
 
 def _insert_user(


### PR DESCRIPTION
## Summary
- use passlib's bcrypt to store passwords securely
- verify stored hashes when logging in
- add passlib dependency

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'passlib')*

------
https://chatgpt.com/codex/tasks/task_e_683fb80e7d008330a6262d912a6fede8