### PR TITLE
Refactor endpoints to use authenticated user

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -137,13 +137,11 @@ def create_session(info: SessionInput, current_user_id: int = Depends(get_curren
     feed.log_session(current_user_id, f"{info.type} {info.duration}m", session_id)
     return {"session_id": session_id}
 
-@app.get('/dashboard/{user_id_param}', response_model=dict) # Added response_model, renamed path param
-def get_dashboard_data(user_id_param: int, current_user_id: int = Depends(get_current_user)): # Renamed
-    if user_id_param != current_user_id:
-        raise HTTPException(status_code=403, detail='Forbidden: Cannot access another user\'s dashboard')
+@app.get('/dashboard/me', response_model=dict)
+def get_dashboard_data(current_user_id: int = Depends(get_current_user)):
     cur = conn.execute(
         'SELECT duration, session_type, session_date, session_time, location FROM sessions WHERE user_id = ?',
-        (user_id_param,) # Use user_id_param from path
+        (current_user_id,)
     )
     records = cur.fetchall()
     sess = [

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -89,7 +89,7 @@ def test_sessions_and_dashboard(client):
         'location': 'Home'
     }, headers=headers)
 
-    resp = client.get(f'/dashboard/{user_id}', headers=headers)
+    resp = client.get('/dashboard/me', headers=headers)
     assert resp.status_code == 200
     data = resp.json()
     assert data['total'] == 25

--- a/web/frontend/src/components/NotificationPreferences.tsx
+++ b/web/frontend/src/components/NotificationPreferences.tsx
@@ -7,19 +7,19 @@ interface Notification {
   message: string;
 }
 
-export default function NotificationPreferences({ userId }: { userId: number }) {
+export default function NotificationPreferences() {
   const [time, setTime] = useState('07:00');
   const [message, setMessage] = useState('Meditate');
   const [notes, setNotes] = useState<Notification[]>([]);
 
   useEffect(() => {
-    getNotifications(userId).then(setNotes);
-  }, [userId]);
+    getNotifications().then(setNotes);
+  }, []);
 
   async function handleAdd(e: React.FormEvent) {
     e.preventDefault();
-    await addNotification(userId, time, message);
-    getNotifications(userId).then(setNotes);
+    await addNotification(time, message);
+    getNotifications().then(setNotes);
   }
 
   return (

--- a/web/frontend/src/pages/EditProfile.tsx
+++ b/web/frontend/src/pages/EditProfile.tsx
@@ -7,9 +7,9 @@ export default function EditProfile() {
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    await updateBio(1, bio);
+    await updateBio(bio);
     if (file) {
-      await uploadPhoto(1, file);
+      await uploadPhoto(file);
     }
     alert('Profile updated');
   }

--- a/web/frontend/src/pages/MoodHistory.tsx
+++ b/web/frontend/src/pages/MoodHistory.tsx
@@ -10,7 +10,7 @@ export default function MoodHistory() {
   const [history, setHistory] = useState<Mood[]>([]);
 
   useEffect(() => {
-    getMoodHistory(1).then(setHistory);
+    getMoodHistory().then(setHistory);
   }, []);
 
   return (

--- a/web/frontend/src/pages/Subscription.tsx
+++ b/web/frontend/src/pages/Subscription.tsx
@@ -9,13 +9,13 @@ export default function Subscription() {
   const [sub, setSub] = useState<Sub | null>(null);
 
   useEffect(() => {
-    getSubscription(1).then(setSub);
+    getSubscription().then(setSub);
   }, []);
 
   async function toggle() {
     if (!sub) return;
     const next = sub.tier === 'premium' ? 'free' : 'premium';
-    await updateSubscription(1, next);
+    await updateSubscription(next);
     setSub({ tier: next });
   }
 

--- a/web/frontend/src/services/api.ts
+++ b/web/frontend/src/services/api.ts
@@ -45,13 +45,13 @@ export async function logSession(data: SessionData) {
 }
 
 export async function getDashboard() {
-  const res = await fetch(`${API_URL}/dashboard/1`, { headers: getAuthHeader() });
+  const res = await fetch(`${API_URL}/dashboard/me`, { headers: getAuthHeader() });
   if (!res.ok) return null;
   return res.json();
 }
 
 export async function getFeed() {
-  const res = await fetch(`${API_URL}/feed/1`, { headers: getAuthHeader() });
+  const res = await fetch(`${API_URL}/feed`, { headers: getAuthHeader() });
   if (!res.ok) return [];
   return res.json();
 }
@@ -66,54 +66,54 @@ export async function joinCommunityChallenge(challengeId: number) {
   await fetch(`${API_URL}/challenges/join`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...getAuthHeader() },
-    body: JSON.stringify({ user_id: 1, challenge_id: challengeId })
+    body: JSON.stringify({ challenge_id: challengeId })
   });
 }
 
-export async function getMoodHistory(userId: number) {
-  const res = await fetch(`${API_URL}/moods/${userId}`, { headers: getAuthHeader() });
+export async function getMoodHistory() {
+  const res = await fetch(`${API_URL}/moods`, { headers: getAuthHeader() });
   if (!res.ok) return [];
   return res.json();
 }
 
-export async function getSubscription(userId: number) {
-  const res = await fetch(`${API_URL}/subscriptions/${userId}`, { headers: getAuthHeader() });
+export async function getSubscription() {
+  const res = await fetch(`${API_URL}/subscriptions/me`, { headers: getAuthHeader() });
   if (!res.ok) return null;
   return res.json();
 }
 
-export async function updateSubscription(userId: number, tier: string) {
-  await fetch(`${API_URL}/subscriptions/${userId}`, {
-    method: 'POST',
+export async function updateSubscription(tier: string) {
+  await fetch(`${API_URL}/subscriptions/me`, {
+    method: 'PUT',
     headers: { 'Content-Type': 'application/json', ...getAuthHeader() },
     body: JSON.stringify({ tier })
   });
 }
 
-export async function addNotification(userId: number, time: string, message: string) {
+export async function addNotification(time: string, message: string) {
   await fetch(`${API_URL}/notifications`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...getAuthHeader() },
-    body: JSON.stringify({ user_id: userId, reminder_time: time, message })
+    body: JSON.stringify({ reminder_time: time, message })
   });
 }
 
-export async function getNotifications(userId: number) {
-  const res = await fetch(`${API_URL}/notifications/${userId}`, { headers: getAuthHeader() });
+export async function getNotifications() {
+  const res = await fetch(`${API_URL}/notifications`, { headers: getAuthHeader() });
   if (!res.ok) return [];
   return res.json();
 }
 
-export async function updateBio(userId: number, bio: string) {
-  await fetch(`${API_URL}/users/${userId}/bio`, {
+export async function updateBio(bio: string) {
+  await fetch(`${API_URL}/users/me/bio`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json', ...getAuthHeader() },
     body: JSON.stringify({ bio })
   });
 }
 
-export async function uploadPhoto(userId: number, file: File) {
-  const res = await fetch(`${API_URL}/users/${userId}/photo`, {
+export async function uploadPhoto(file: File) {
+  const res = await fetch(`${API_URL}/users/me/photo`, {
     method: 'POST',
     headers: { 'X-Filename': file.name, ...getAuthHeader() },
     body: file


### PR DESCRIPTION
## Summary
- derive current user id from token for `/dashboard/me`
- call current-user endpoints from web client
- simplify NotificationPreferences component
- adjust integration test for dashboard endpoint

## Testing
- `npm test --silent` *(fails: vitest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_683fbb74255c8330aa2d2c4a05982b61