### PR TITLE
Remove redundant httpx install from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install httpx
     - name: Run Python tests
       run: pytest -v
 


### PR DESCRIPTION
## Summary
- avoid installing httpx twice in CI workflow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_683fbd5788508330b3f2d96c3897ec9c