### PR TITLE
Add Postgres challenge tables and sync schema

### DIFF
--- a/scripts/init_db.sql
+++ b/scripts/init_db.sql
@@ -116,6 +116,7 @@ CREATE TABLE IF NOT EXISTS user_notifications (
     message TEXT,
     is_enabled INTEGER DEFAULT 1,
     FOREIGN KEY(user_id) REFERENCES users(id)
+);
 
 -- Social activity feed items
 CREATE TABLE IF NOT EXISTS activity_feed (
@@ -129,6 +130,7 @@ CREATE TABLE IF NOT EXISTS activity_feed (
     FOREIGN KEY(user_id) REFERENCES users(id),
     FOREIGN KEY(target_user_id) REFERENCES users(id),
     FOREIGN KEY(related_session_id) REFERENCES sessions(id)
+);
   
 -- Advertisements for in-app promotions or announcements
 CREATE TABLE IF NOT EXISTS advertisements (

--- a/scripts/init_db_postgres.sql
+++ b/scripts/init_db_postgres.sql
@@ -79,6 +79,25 @@ CREATE TABLE IF NOT EXISTS subscriptions (
     FOREIGN KEY(user_id) REFERENCES users(id)
 );
 
+-- Community challenges for shared meditation goals
+CREATE TABLE IF NOT EXISTS community_challenges (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    target_minutes INTEGER NOT NULL,
+    start_date DATE NOT NULL,
+    end_date DATE NOT NULL
+);
+
+-- Track progress for users participating in community challenges
+CREATE TABLE IF NOT EXISTS challenge_progress (
+    user_id INTEGER NOT NULL,
+    challenge_id INTEGER NOT NULL,
+    minutes INTEGER DEFAULT 0,
+    PRIMARY KEY (user_id, challenge_id),
+    FOREIGN KEY(user_id) REFERENCES users(id),
+    FOREIGN KEY(challenge_id) REFERENCES community_challenges(id)
+);
+
 -- Notification reminders for users
 CREATE TABLE IF NOT EXISTS user_notifications (
     id SERIAL PRIMARY KEY,
@@ -87,6 +106,7 @@ CREATE TABLE IF NOT EXISTS user_notifications (
     message TEXT,
     is_enabled BOOLEAN DEFAULT TRUE,
     FOREIGN KEY(user_id) REFERENCES users(id)
+);
 
 -- Social activity feed items
 CREATE TABLE IF NOT EXISTS activity_feed (
@@ -100,6 +120,7 @@ CREATE TABLE IF NOT EXISTS activity_feed (
     FOREIGN KEY(user_id) REFERENCES users(id),
     FOREIGN KEY(target_user_id) REFERENCES users(id),
     FOREIGN KEY(related_session_id) REFERENCES sessions(id)
+);
 
 -- Advertisements for in-app promotions or announcements
 CREATE TABLE IF NOT EXISTS advertisements (


### PR DESCRIPTION
## Summary
- create `community_challenges` and `challenge_progress` in Postgres init script
- close table definitions for notifications and activity feed
- update SQLite schema to close those tables
- match types between SQLite and Postgres

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ActivityFeed.log_session() takes 3 positional arguments but 4 were given)*

------
https://chatgpt.com/codex/tasks/task_e_683fbcd42b2c83308b52301ef71cb90f