### PR TITLE
Fix iOS workflow steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,6 @@ jobs:
       if: hashFiles('web/frontend/cypress.config.*') != ''
       working-directory: web/frontend
       run: npx cypress run
-    - name: Run iOS UI tests
-      if: runner.os == 'macOS'
-      run: |
-        xcodebuild test -scheme MindfulConnectUITests \
-          -destination 'platform=iOS Simulator,name=iPhone 14'
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
@@ -55,6 +50,6 @@ jobs:
     - uses: actions/checkout@v3
     - name: Run iOS UI tests
       run: |
-        xcodebuild test -project ios/MindfulConnect/MindfulConnect.xcodeproj \
+        xcodebuild test -project ios/MindfulConnect.xcodeproj \
           -scheme MindfulConnect \
           -destination 'platform=iOS Simulator,name=iPhone 14,OS=latest'


### PR DESCRIPTION
## Summary
- remove the macOS-only test step from the `test` job
- point the `ios-tests` job at the correct Xcode project

## Testing
- `pytest -q` *(fails: sqlite3.OperationalError near "CREATE")*

------
https://chatgpt.com/codex/tasks/task_e_683fbd40b4988330b99253a30b080b03