### PR TITLE
Remove unused Playwright step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,6 @@ jobs:
     - name: Run frontend unit tests
       working-directory: web/frontend
       run: npm test
-    - name: Run Playwright tests
-      if: hashFiles('web/frontend/playwright.config.*') != ''
-      working-directory: web/frontend
-      run: |
-        npx playwright install --with-deps
-        npx playwright test
     - name: Run Cypress tests
       if: hashFiles('web/frontend/cypress.config.*') != ''
       working-directory: web/frontend


### PR DESCRIPTION
## Summary
- remove the Playwright test run from the CI workflow since no Playwright config exists

## Testing
- `npm test` *(fails: vitest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_683fbd48118483308627fd48950a698d