### PR TITLE
Add social login and profile view UI

### DIFF
--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import CommunityChallenges from "./pages/CommunityChallenges";
 import MoodHistory from "./pages/MoodHistory";
 import Subscription from "./pages/Subscription";
 import EditProfile from "./pages/EditProfile";
+import UserProfile from "./pages/UserProfile";
 import "./App.css";
 
 export default function App() {
@@ -25,6 +26,7 @@ export default function App() {
         <Route path="/moods" element={<MoodHistory />} />
         <Route path="/subscription" element={<Subscription />} />
         <Route path="/profile" element={<EditProfile />} />
+        <Route path="/profile/:id" element={<UserProfile />} />
         <Route path="*" element={<Navigate to="/login" />} />
       </Routes>
     </BrowserRouter>

--- a/web/frontend/src/components/SocialLoginButton.tsx
+++ b/web/frontend/src/components/SocialLoginButton.tsx
@@ -1,0 +1,26 @@
+import { useNavigate } from "react-router-dom";
+import { socialLogin } from "../services/api";
+
+interface Props {
+  provider: string;
+  label: string;
+}
+
+export default function SocialLoginButton({ provider, label }: Props) {
+  const navigate = useNavigate();
+
+  async function handleClick() {
+    // Simulate provider sign-in then call the mocked API
+    const token = await socialLogin(provider, "dummy_token");
+    if (token) {
+      localStorage.setItem("token", token);
+      navigate("/dashboard");
+    }
+  }
+
+  return (
+    <button type="button" onClick={handleClick} style={{ margin: "0 0.5rem" }}>
+      Login with {label}
+    </button>
+  );
+}

--- a/web/frontend/src/pages/EditProfile.tsx
+++ b/web/frontend/src/pages/EditProfile.tsx
@@ -1,9 +1,14 @@
 import { useState } from "react";
-import { updateBio, uploadPhoto } from "../services/api";
+import {
+  updateBio,
+  uploadPhoto,
+  updateProfileVisibility,
+} from "../services/api";
 
 export default function EditProfile() {
   const [bio, setBio] = useState("");
   const [file, setFile] = useState<File | null>(null);
+  const [isPublic, setIsPublic] = useState(true);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -27,6 +32,18 @@ export default function EditProfile() {
           <input
             type="file"
             onChange={(e) => setFile(e.target.files?.[0] || null)}
+          />
+        </label>
+        <label>
+          Profile is Public
+          <input
+            type="checkbox"
+            checked={isPublic}
+            onChange={async (e) => {
+              const value = e.target.checked;
+              setIsPublic(value);
+              await updateProfileVisibility(value);
+            }}
           />
         </label>
         <button type="submit">Save</button>

--- a/web/frontend/src/pages/Login.tsx
+++ b/web/frontend/src/pages/Login.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { login } from "../services/api";
+import SocialLoginButton from "../components/SocialLoginButton";
 
 export default function Login() {
   const navigate = useNavigate();
@@ -38,6 +39,10 @@ export default function Login() {
         </label>
         <button type="submit">Login</button>
       </form>
+      <div style={{ marginTop: "1rem" }}>
+        <SocialLoginButton provider="google" label="Google" />
+        <SocialLoginButton provider="facebook" label="Facebook" />
+      </div>
     </main>
   );
 }

--- a/web/frontend/src/pages/UserProfile.test.tsx
+++ b/web/frontend/src/pages/UserProfile.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { describe, it, expect, vi } from "vitest";
+import UserProfile from "./UserProfile";
+
+vi.mock("../services/api", () => ({
+  getUserProfile: () =>
+    Promise.resolve({
+      user_id: 1,
+      display_name: "Tester",
+      bio: "hello",
+      photo_url: "",
+      is_public: true,
+    }),
+}));
+
+describe("UserProfile page", () => {
+  it("loads profile data", async () => {
+    render(
+      <MemoryRouter initialEntries={["/profile/1"]}>
+        <Routes>
+          <Route path="/profile/:id" element={<UserProfile />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    expect(await screen.findByText("Tester")).toBeInTheDocument();
+  });
+});

--- a/web/frontend/src/pages/UserProfile.tsx
+++ b/web/frontend/src/pages/UserProfile.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { getUserProfile, UserProfile as Profile } from "../services/api";
+
+export default function UserProfile() {
+  const { id } = useParams();
+  const [profile, setProfile] = useState<Profile | null>(null);
+
+  useEffect(() => {
+    if (id) {
+      getUserProfile(id).then(setProfile);
+    }
+  }, [id]);
+
+  if (!profile) {
+    return <main>Loading...</main>;
+  }
+
+  return (
+    <main>
+      <h1>{profile.display_name}</h1>
+      {profile.photo_url && (
+        <img src={profile.photo_url} alt="profile" width={150} />
+      )}
+      <p>{profile.bio}</p>
+      <section>
+        <h2>Stats</h2>
+        <p>Total Minutes: {profile.total_minutes}</p>
+        <p>Sessions: {profile.session_count}</p>
+      </section>
+      <section>
+        <h2>Recent Activity</h2>
+        <ul>
+          {profile.recent_activity.map((item, idx) => (
+            <li key={idx}>{item}</li>
+          ))}
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/web/frontend/src/services/api.ts
+++ b/web/frontend/src/services/api.ts
@@ -4,8 +4,8 @@ function getAuthHeader() {
   // Access tokens are stored in ``localStorage`` after login. When present we
   // send them as a ``Bearer`` token so protected endpoints authenticate the
   // current user.
-  const token = localStorage.getItem('token');
-  return token ? { 'Authorization': `Bearer ${token}` } : {};
+  const token = localStorage.getItem("token");
+  return token ? { Authorization: `Bearer ${token}` } : {};
 }
 
 export async function signup(
@@ -136,4 +136,54 @@ export async function uploadPhoto(file: File) {
   });
   if (!res.ok) return null;
   return res.json();
+}
+
+// --- Mocked Social & Profile APIs ---
+
+export async function socialLogin(
+  provider: string,
+  token: string,
+): Promise<string | null> {
+  // Simulate a network delay then resolve a fake token
+  return new Promise((resolve) => {
+    setTimeout(() => resolve("mock_access_token"), 300);
+  });
+}
+
+export async function updateProfileVisibility(isPublic: boolean) {
+  // Placeholder mock implementation
+  return new Promise((resolve) => setTimeout(resolve, 200));
+}
+
+export interface UserProfile {
+  user_id: number;
+  display_name: string;
+  bio: string;
+  photo_url: string;
+  is_public: boolean;
+  total_minutes: number;
+  session_count: number;
+  recent_activity: string[];
+}
+
+export async function getUserProfile(
+  userId: string,
+): Promise<UserProfile | null> {
+  // Return mock profile data
+  return new Promise((resolve) =>
+    setTimeout(
+      () =>
+        resolve({
+          user_id: Number(userId),
+          display_name: "Mock User",
+          bio: "This is a mock profile.",
+          photo_url: "",
+          is_public: true,
+          total_minutes: 123,
+          session_count: 45,
+          recent_activity: ["Meditated for 10 minutes", "Completed challenge"],
+        }),
+      200,
+    ),
+  );
 }


### PR DESCRIPTION
## Summary
- mock social/profile APIs
- add social login button
- allow setting profile visibility
- create user profile view page
- route to user profile view
- test new profile page

## Testing
- `npm test -- --run` *(fails: vitest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*


------
https://chatgpt.com/codex/tasks/task_e_68404d1588108330906aea2866daf178