### PR TITLE
Add comment/encouragement/ad API methods

### DIFF
--- a/web/frontend/src/components/Advertisement.tsx
+++ b/web/frontend/src/components/Advertisement.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+import { Ad, getRandomAd, getSubscription } from "../services/api";
+
+export default function Advertisement() {
+  const [ad, setAd] = useState<Ad | null>(null);
+
+  useEffect(() => {
+    async function loadAd() {
+      const sub = await getSubscription();
+      if (sub && sub.tier === "free") {
+        const a = await getRandomAd();
+        if (a) setAd(a);
+      }
+    }
+    loadAd();
+  }, []);
+
+  if (!ad) return null;
+
+  return (
+    <aside className="ad">
+      <p>{ad.text}</p>
+    </aside>
+  );
+}
+

--- a/web/frontend/src/components/FeedItemCard.tsx
+++ b/web/frontend/src/components/FeedItemCard.tsx
@@ -1,0 +1,77 @@
+import { useState } from "react";
+import {
+  addFeedComment,
+  addFeedEncouragement,
+  FeedComment,
+  FeedEncouragement,
+} from "../services/api";
+
+export interface FeedItem {
+  item_id: number;
+  user_id: number;
+  item_type: string;
+  message: string;
+  comments?: FeedComment[];
+  encouragements?: FeedEncouragement[];
+}
+
+interface Props {
+  item: FeedItem;
+}
+
+export default function FeedItemCard({ item }: Props) {
+  const [comments, setComments] = useState<FeedComment[]>(item.comments || []);
+  const [encs, setEncs] = useState<FeedEncouragement[]>(item.encouragements || []);
+  const [commentText, setCommentText] = useState("");
+  const [encText, setEncText] = useState("");
+
+  async function handleAddComment() {
+    if (!commentText) return;
+    const newComment = await addFeedComment(item.item_id, commentText);
+    if (newComment) setComments([...comments, newComment]);
+    setCommentText("");
+  }
+
+  async function handleAddEnc() {
+    if (!encText) return;
+    const newEnc = await addFeedEncouragement(item.item_id, encText);
+    if (newEnc) setEncs([...encs, newEnc]);
+    setEncText("");
+  }
+
+  return (
+    <li>
+      <p>{item.message}</p>
+      {comments.length > 0 && (
+        <ul>
+          {comments.map((c) => (
+            <li key={c.comment_id}>{c.text}</li>
+          ))}
+        </ul>
+      )}
+      {encs.length > 0 && (
+        <ul>
+          {encs.map((e) => (
+            <li key={e.encouragement_id}>{e.text}</li>
+          ))}
+        </ul>
+      )}
+      <div>
+        <input
+          placeholder="Add comment"
+          value={commentText}
+          onChange={(e) => setCommentText(e.target.value)}
+        />
+        <button onClick={handleAddComment}>Comment</button>
+      </div>
+      <div>
+        <input
+          placeholder="Add encouragement"
+          value={encText}
+          onChange={(e) => setEncText(e.target.value)}
+        />
+        <button onClick={handleAddEnc}>Encourage</button>
+      </div>
+    </li>
+  );
+}

--- a/web/frontend/src/pages/ActivityFeed.test.tsx
+++ b/web/frontend/src/pages/ActivityFeed.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import ActivityFeedPage from "./ActivityFeed";
+
+const addComment = vi.fn();
+const addEnc = vi.fn();
+const getAd = vi.fn();
+
+vi.mock("../services/api", () => ({
+  getFeed: () =>
+    Promise.resolve([
+      {
+        item_id: 1,
+        user_id: 2,
+        item_type: "session",
+        message: "Morning",
+        comments: [
+          { comment_id: 1, feed_item_id: 1, user_id: 3, text: "Nice" },
+        ],
+        encouragements: [],
+      },
+    ]),
+  addFeedComment: (...args: any[]) => {
+    addComment(...args);
+    return Promise.resolve({
+      comment_id: 2,
+      feed_item_id: 1,
+      user_id: 1,
+      text: args[1],
+    });
+  },
+  addFeedEncouragement: (...args: any[]) => {
+    addEnc(...args);
+    return Promise.resolve({
+      encouragement_id: 3,
+      feed_item_id: 1,
+      user_id: 1,
+      text: args[1],
+    });
+  },
+  getSubscription: () => Promise.resolve({ tier: "free" }),
+  getRandomAd: () => {
+    getAd();
+    return Promise.resolve({ ad_id: 1, text: "Buy now" });
+  },
+}));
+
+describe("ActivityFeed page", () => {
+  it("shows comments and allows posting", async () => {
+    render(<ActivityFeedPage />);
+    expect(await screen.findByText("Nice")).toBeInTheDocument();
+    fireEvent.change(screen.getByPlaceholderText("Add comment"), {
+      target: { value: "Hello" },
+    });
+    fireEvent.click(screen.getByText("Comment"));
+    expect(addComment).toHaveBeenCalled();
+    expect(await screen.findByText("Buy now")).toBeInTheDocument();
+  });
+});

--- a/web/frontend/src/pages/ActivityFeed.tsx
+++ b/web/frontend/src/pages/ActivityFeed.tsx
@@ -1,12 +1,7 @@
 import { useEffect, useState } from "react";
 import { getFeed } from "../services/api";
-
-interface FeedItem {
-  item_id: number;
-  user_id: number;
-  item_type: string;
-  message: string;
-}
+import FeedItemCard, { FeedItem } from "../components/FeedItemCard";
+import Advertisement from "../components/Advertisement";
 
 export default function ActivityFeedPage() {
   const [items, setItems] = useState<FeedItem[]>([]);
@@ -20,9 +15,10 @@ export default function ActivityFeedPage() {
       <h1>Activity Feed</h1>
       <ul>
         {items.map((i) => (
-          <li key={i.item_id}>{i.message}</li>
+          <FeedItemCard key={i.item_id} item={i} />
         ))}
       </ul>
+      <Advertisement />
     </main>
   );
 }

--- a/web/frontend/src/services/api.ts
+++ b/web/frontend/src/services/api.ts
@@ -46,6 +46,25 @@ export interface SessionData {
   moodAfter: number;
 }
 
+export interface FeedComment {
+  comment_id: number;
+  feed_item_id: number;
+  user_id: number;
+  text: string;
+}
+
+export interface FeedEncouragement {
+  encouragement_id: number;
+  feed_item_id: number;
+  user_id: number;
+  text: string;
+}
+
+export interface Ad {
+  ad_id: number;
+  text: string;
+}
+
 export async function logSession(data: SessionData) {
   await fetch(`${API_URL}/sessions`, {
     method: "POST",
@@ -136,4 +155,36 @@ export async function uploadPhoto(file: File) {
   });
   if (!res.ok) return null;
   return res.json();
+}
+
+export async function addFeedComment(
+  feedItemId: number,
+  text: string,
+): Promise<FeedComment | null> {
+  const res = await fetch(`${API_URL}/feed/${feedItemId}/comment`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...getAuthHeader() },
+    body: JSON.stringify({ text }),
+  });
+  if (!res.ok) return null;
+  return res.json() as Promise<FeedComment>;
+}
+
+export async function addFeedEncouragement(
+  feedItemId: number,
+  text: string,
+): Promise<FeedEncouragement | null> {
+  const res = await fetch(`${API_URL}/feed/${feedItemId}/encourage`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...getAuthHeader() },
+    body: JSON.stringify({ text }),
+  });
+  if (!res.ok) return null;
+  return res.json() as Promise<FeedEncouragement>;
+}
+
+export async function getRandomAd(): Promise<Ad | null> {
+  const res = await fetch(`${API_URL}/ads/random`, { headers: getAuthHeader() });
+  if (!res.ok) return null;
+  return res.json() as Promise<Ad>;
 }


### PR DESCRIPTION
## Summary
- extend `api.ts` with interfaces for feed interactions and ads
- add helper functions for posting feed comments and encouragements
- add helper to fetch random ads
- add `Advertisement` component for free tier users
- integrate ads into the activity feed UI

## Testing
- `npm test --silent` *(fails: vitest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_68404d2d4d50833084f9c874df04c2c0