### PR TITLE
Add SwiftUI UI for login and settings

### DIFF
--- a/ios/MindfulConnect/APIClient.swift
+++ b/ios/MindfulConnect/APIClient.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Combine
+
+/// Handles communication with the backend API for authentication,
+/// profile settings and custom meditation types.
+public struct APIClient {
+    public var baseURL: URL
+    public var session: URLSession
+
+    public init(baseURL: URL = URL(string: "http://localhost:8000")!,
+                session: URLSession = .shared) {
+        self.baseURL = baseURL
+        self.session = session
+    }
+
+    private func requestData(_ endpoint: String,
+                             method: String = "GET",
+                             body: Data? = nil,
+                             authToken: String? = nil) -> AnyPublisher<Data, Error> {
+        var urlRequest = URLRequest(url: baseURL.appendingPathComponent(endpoint))
+        urlRequest.httpMethod = method
+        urlRequest.httpBody = body
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let token = authToken {
+            urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        return session.dataTaskPublisher(for: urlRequest)
+            .map(\.data)
+            .mapError { $0 as Error }
+            .eraseToAnyPublisher()
+    }
+
+    private func request<T: Decodable>(_ endpoint: String,
+                                       method: String = "GET",
+                                       body: Data? = nil,
+                                       authToken: String? = nil) -> AnyPublisher<T, Error> {
+        requestData(endpoint, method: method, body: body, authToken: authToken)
+            .decode(type: T.self, decoder: JSONDecoder())
+            .eraseToAnyPublisher()
+    }
+
+    // MARK: - Social Login
+    public func socialLogin(_ requestBody: SocialLoginRequest) -> AnyPublisher<SocialLoginResponse, Error> {
+        let data = try? JSONEncoder().encode(requestBody)
+        return request("auth/social", method: "POST", body: data)
+    }
+
+    // MARK: - Profile Visibility
+    public func updateProfileVisibility(_ requestBody: ProfileVisibilityRequest,
+                                        authToken: String) -> AnyPublisher<ProfileVisibilityResponse, Error> {
+        let data = try? JSONEncoder().encode(requestBody)
+        return request("profile/visibility", method: "PATCH", body: data, authToken: authToken)
+    }
+
+    // MARK: - Custom Meditation Types
+    public func fetchMeditationTypes(authToken: String) -> AnyPublisher<[MeditationType], Error> {
+        request("meditation_types", authToken: authToken)
+    }
+
+    public func createMeditationType(_ requestBody: CreateMeditationTypeRequest,
+                                     authToken: String) -> AnyPublisher<MeditationType, Error> {
+        let data = try? JSONEncoder().encode(requestBody)
+        return request("meditation_types", method: "POST", body: data, authToken: authToken)
+    }
+
+    public func updateMeditationType(id: UUID,
+                                     requestBody: UpdateMeditationTypeRequest,
+                                     authToken: String) -> AnyPublisher<MeditationType, Error> {
+        let data = try? JSONEncoder().encode(requestBody)
+        let endpoint = "meditation_types/\(id.uuidString)"
+        return request(endpoint, method: "PUT", body: data, authToken: authToken)
+    }
+
+    public func deleteMeditationType(id: UUID, authToken: String) -> AnyPublisher<Void, Error> {
+        let endpoint = "meditation_types/\(id.uuidString)"
+        return requestData(endpoint, method: "DELETE", authToken: authToken)
+            .map { _ in () }
+            .eraseToAnyPublisher()
+    }
+}

--- a/ios/MindfulConnect/APIModels.swift
+++ b/ios/MindfulConnect/APIModels.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+public struct SocialLoginRequest: Codable {
+    public let provider: String
+    public let token: String
+}
+
+public struct UserProfile: Codable {
+    public let id: UUID
+    public let name: String
+    public let email: String
+    public let visibility: String
+}
+
+public struct SocialLoginResponse: Codable {
+    public let user: UserProfile
+    public let authToken: String
+}
+
+public struct ProfileVisibilityRequest: Codable {
+    public let visibility: String
+}
+
+public struct ProfileVisibilityResponse: Codable {
+    public let user: UserProfile
+}
+
+public struct MeditationType: Codable, Identifiable {
+    public let id: UUID
+    public let name: String
+}
+
+public struct CreateMeditationTypeRequest: Codable {
+    public let name: String
+}
+
+public struct UpdateMeditationTypeRequest: Codable {
+    public let name: String
+}

--- a/ios/MindfulConnect/AppViewModel.swift
+++ b/ios/MindfulConnect/AppViewModel.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Combine
+
+/// Holds global app state for authentication and user preferences.
+public class AppViewModel: ObservableObject {
+    @Published public private(set) var authToken: String?
+    @Published public private(set) var user: UserProfile?
+    @Published public var meditationTypes: [MeditationType] = []
+    private var cancellables = Set<AnyCancellable>()
+
+    private let api: MockAPIClient
+
+    public init(api: MockAPIClient = MockAPIClient()) {
+        self.api = api
+    }
+
+    public var isLoggedIn: Bool { authToken != nil }
+
+    public func socialLogin(provider: String, token: String) {
+        let request = SocialLoginRequest(provider: provider, token: token)
+        api.socialLogin(request)
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { [weak self] response in
+                self?.authToken = response.authToken
+                self?.user = response.user
+            })
+            .store(in: &cancellables)
+    }
+
+    public func updateVisibility(to visibility: String) {
+        guard let token = authToken else { return }
+        let request = ProfileVisibilityRequest(visibility: visibility)
+        api.updateProfileVisibility(request, authToken: token)
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { [weak self] response in
+                self?.user = response.user
+            })
+            .store(in: &cancellables)
+    }
+
+    public func loadMeditationTypes() {
+        guard let token = authToken else { return }
+        api.fetchMeditationTypes(authToken: token)
+            .sink(receiveCompletion: { _ in }, receiveValue: { [weak self] types in
+                self?.meditationTypes = types
+            })
+            .store(in: &cancellables)
+    }
+
+    public func addMeditationType(name: String) {
+        guard let token = authToken else { return }
+        let request = CreateMeditationTypeRequest(name: name)
+        api.createMeditationType(request, authToken: token)
+            .sink(receiveCompletion: { _ in }, receiveValue: { [weak self] type in
+                self?.meditationTypes.append(type)
+            })
+            .store(in: &cancellables)
+    }
+
+    public func deleteMeditationType(id: UUID) {
+        guard let token = authToken else { return }
+        api.deleteMeditationType(id: id, authToken: token)
+            .sink(receiveCompletion: { _ in }, receiveValue: { [weak self] in
+                self?.meditationTypes.removeAll { $0.id == id }
+            })
+            .store(in: &cancellables)
+    }
+}

--- a/ios/MindfulConnect/ContentView.swift
+++ b/ios/MindfulConnect/ContentView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+/// Root view that switches between login and main content based on auth state.
+struct ContentView: View {
+    @EnvironmentObject var viewModel: AppViewModel
+
+    var body: some View {
+        NavigationView {
+            if viewModel.isLoggedIn {
+                List {
+                    NavigationLink("Profile Settings") {
+                        ProfileSettingsView()
+                    }
+                    NavigationLink("Meditation Types") {
+                        MeditationTypesView()
+                    }
+                }
+                .navigationTitle("Mindful Connect")
+            } else {
+                SocialLoginView()
+            }
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView().environmentObject(AppViewModel())
+    }
+}

--- a/ios/MindfulConnect/MeditationTypesView.swift
+++ b/ios/MindfulConnect/MeditationTypesView.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+/// Displays and manages custom meditation types for the authenticated user.
+struct MeditationTypesView: View {
+    @EnvironmentObject var viewModel: AppViewModel
+    @State private var newTypeName: String = ""
+
+    var body: some View {
+        VStack {
+            List {
+                ForEach(viewModel.meditationTypes) { type in
+                    Text(type.name)
+                        .swipeActions {
+                            Button(role: .destructive) {
+                                viewModel.deleteMeditationType(id: type.id)
+                            } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
+                        }
+                }
+            }
+
+            HStack {
+                TextField("New type name", text: $newTypeName)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                Button("Add") {
+                    guard !newTypeName.isEmpty else { return }
+                    viewModel.addMeditationType(name: newTypeName)
+                    newTypeName = ""
+                }
+            }
+            .padding()
+        }
+        .navigationTitle("Meditation Types")
+        .onAppear { viewModel.loadMeditationTypes() }
+    }
+}
+
+struct MeditationTypesView_Previews: PreviewProvider {
+    static var previews: some View {
+        let vm = AppViewModel()
+        vm.authToken = "token"
+        vm.meditationTypes = [
+            MeditationType(id: UUID(), name: "Breathing"),
+            MeditationType(id: UUID(), name: "Walking")
+        ]
+        return MeditationTypesView().environmentObject(vm)
+    }
+}

--- a/ios/MindfulConnect/MindfulConnectApp.swift
+++ b/ios/MindfulConnect/MindfulConnectApp.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@main
+struct MindfulConnectApp: App {
+    @StateObject private var viewModel = AppViewModel()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(viewModel)
+        }
+    }
+}

--- a/ios/MindfulConnect/MockAPIClient.swift
+++ b/ios/MindfulConnect/MockAPIClient.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Combine
+
+/// Provides mocked API responses for development and previews.
+public struct MockAPIClient {
+    public init() {}
+
+    public func socialLogin(_ request: SocialLoginRequest) -> AnyPublisher<SocialLoginResponse, Error> {
+        let profile = UserProfile(
+            id: UUID(),
+            name: "Demo User",
+            email: "demo@example.com",
+            visibility: "public"
+        )
+        let response = SocialLoginResponse(user: profile, authToken: "mock-token")
+        return Just(response)
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher()
+    }
+
+    public func updateProfileVisibility(_ request: ProfileVisibilityRequest, authToken: String) -> AnyPublisher<ProfileVisibilityResponse, Error> {
+        let profile = UserProfile(
+            id: UUID(),
+            name: "Demo User",
+            email: "demo@example.com",
+            visibility: request.visibility
+        )
+        let response = ProfileVisibilityResponse(user: profile)
+        return Just(response)
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher()
+    }
+
+    public func fetchMeditationTypes(authToken: String) -> AnyPublisher<[MeditationType], Error> {
+        let types = [
+            MeditationType(id: UUID(), name: "Breathing"),
+            MeditationType(id: UUID(), name: "Walking")
+        ]
+        return Just(types)
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher()
+    }
+
+    public func createMeditationType(_ request: CreateMeditationTypeRequest, authToken: String) -> AnyPublisher<MeditationType, Error> {
+        let type = MeditationType(id: UUID(), name: request.name)
+        return Just(type)
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher()
+    }
+
+    public func updateMeditationType(id: UUID, request: UpdateMeditationTypeRequest, authToken: String) -> AnyPublisher<MeditationType, Error> {
+        let type = MeditationType(id: id, name: request.name)
+        return Just(type)
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher()
+    }
+
+    public func deleteMeditationType(id: UUID, authToken: String) -> AnyPublisher<Void, Error> {
+        return Just(())
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher()
+    }
+}

--- a/ios/MindfulConnect/ProfileSettingsView.swift
+++ b/ios/MindfulConnect/ProfileSettingsView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+/// Allows the user to toggle their profile visibility between public and private.
+struct ProfileSettingsView: View {
+    @EnvironmentObject var viewModel: AppViewModel
+
+    var body: some View {
+        Form {
+            Toggle(isOn: Binding(
+                get: { viewModel.user?.visibility == "public" },
+                set: { isPublic in
+                    let visibility = isPublic ? "public" : "private"
+                    viewModel.updateVisibility(to: visibility)
+                }
+            )) {
+                Text("Public Profile")
+            }
+        }
+        .navigationTitle("Profile")
+    }
+}
+
+struct ProfileSettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        let vm = AppViewModel()
+        vm.user = UserProfile(id: UUID(), name: "Demo", email: "demo@example.com", visibility: "public")
+        return ProfileSettingsView().environmentObject(vm)
+    }
+}

--- a/ios/MindfulConnect/SocialLoginView.swift
+++ b/ios/MindfulConnect/SocialLoginView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+/// Simple UI allowing a user to perform a mocked social login.
+struct SocialLoginView: View {
+    @EnvironmentObject var viewModel: AppViewModel
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("Welcome to Mindful Connect")
+                .font(.title)
+
+            Button(action: {
+                viewModel.socialLogin(provider: "google", token: "demo-token")
+            }) {
+                Text("Login with Google")
+                    .padding()
+                    .frame(maxWidth: .infinity)
+                    .background(Color.blue)
+                    .foregroundColor(.white)
+                    .cornerRadius(8)
+            }
+        }
+        .padding()
+    }
+}
+
+struct SocialLoginView_Previews: PreviewProvider {
+    static var previews: some View {
+        SocialLoginView().environmentObject(AppViewModel())
+    }
+}

--- a/ios/README.md
+++ b/ios/README.md
@@ -24,3 +24,23 @@ xcodebuild test -project MindfulConnect.xcodeproj \
 ```
 
 The command builds the app and executes the `MindfulConnectUITests` target.
+
+## Networking Layer
+
+`APIClient` in `MindfulConnect` provides Combine publishers for the mocked backend
+endpoints. It includes calls for social login, updating profile visibility and
+managing custom meditation types. `MockAPIClient` returns sample data so the app
+can be developed without running the server.
+
+## SwiftUI Screens
+
+The minimal SwiftUI interface demonstrates how the new networking layer can be used.
+`SocialLoginView` performs a mocked social login and stores the resulting auth token
+in `AppViewModel`. `ProfileSettingsView` exposes a toggle to change profile
+visibility, while `MeditationTypesView` lists and lets you add or delete custom
+meditation types.
+
+`MindfulConnectApp` sets up the shared `AppViewModel` and shows `ContentView`,
+which switches between the login screen and the main settings views once
+authenticated.
+


### PR DESCRIPTION
## Summary
- add `AppViewModel` to hold authentication state and API calls
- create SwiftUI views for social login, profile visibility and meditation types management
- wire them together in `MindfulConnectApp` and `ContentView`
- document the new screens in the iOS README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*


------
https://chatgpt.com/codex/tasks/task_e_68404d358da88330bc29dcb3f867992e