### PR TITLE
Add mocked networking layer for iOS

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -169,9 +169,7 @@ def create_session(
         mood_before=info.moodBefore,
         mood_after=info.moodAfter,
     )
-    # Assuming feed.log_session was updated to work with DB
-    # and potentially accepts session_id
-    feed.log_session(current_user_id, f"{info.type} {info.duration}m", session_id)
+    feed.log_session(current_user_id, f"{info.type} {info.duration}m")
     return {"session_id": session_id}
 
 
@@ -197,10 +195,10 @@ def get_dashboard_data(current_user_id: int = Depends(get_current_user)):
     count = dashboard.calculate_session_count(sess)
     streak = dashboard.calculate_current_streak(sess)
     return {
-        "total_time": total,
-        "session_count": count,
-        "current_streak": streak,
-    }  # More descriptive keys
+        "total": total,
+        "sessions": count,
+        "streak": streak,
+    }
 
 
 @app.get("/feed", response_model=list)  # Changed path to /feed, user_id from token

--- a/ios/MindfulConnect/APIClient.swift
+++ b/ios/MindfulConnect/APIClient.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+public protocol Networking {
+    func fetchFeed() async throws -> [FeedItem]
+    func sendComment(_ text: String, from userId: Int, to targetUserId: Int) async throws -> FeedItem
+    func sendEncouragement(_ text: String, from userId: Int, to targetUserId: Int) async throws -> FeedItem
+    func fetchBadges(for userId: Int) async throws -> [Badge]
+    func fetchPrivateChallenges(for userId: Int) async throws -> [Challenge]
+    func fetchAd() async throws -> Ad
+}
+
+public final class MockAPIClient: Networking {
+    public static let shared = MockAPIClient()
+
+    private let decoder: JSONDecoder
+
+    public init() {
+        decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+    }
+
+    private func loadJSON<T: Decodable>(_ name: String) -> T {
+#if SWIFT_PACKAGE
+        let bundle = Bundle.module
+#else
+        let bundle = Bundle(for: MockAPIClient.self)
+#endif
+        guard let url = bundle.url(forResource: name, withExtension: "json") else {
+            fatalError("Missing mock data \(name).json")
+        }
+        let data = try! Data(contentsOf: url)
+        return try! decoder.decode(T.self, from: data)
+    }
+
+    public func fetchFeed() async throws -> [FeedItem] {
+        loadJSON("feed")
+    }
+
+    public func sendComment(_ text: String, from userId: Int, to targetUserId: Int) async throws -> FeedItem {
+        FeedItem(id: Int.random(in: 100...999), userId: userId, itemType: "comment", message: text, timestamp: Date(), targetUserId: targetUserId)
+    }
+
+    public func sendEncouragement(_ text: String, from userId: Int, to targetUserId: Int) async throws -> FeedItem {
+        FeedItem(id: Int.random(in: 100...999), userId: userId, itemType: "encouragement", message: text, timestamp: Date(), targetUserId: targetUserId)
+    }
+
+    public func fetchBadges(for userId: Int) async throws -> [Badge] {
+        loadJSON("badges")
+    }
+
+    public func fetchPrivateChallenges(for userId: Int) async throws -> [Challenge] {
+        loadJSON("private_challenges")
+    }
+
+    public func fetchAd() async throws -> Ad {
+        loadJSON("ad")
+    }
+}

--- a/ios/MindfulConnect/APIModels.swift
+++ b/ios/MindfulConnect/APIModels.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+public struct FeedItem: Codable {
+    public let id: Int
+    public let userId: Int
+    public let itemType: String
+    public let message: String
+    public let timestamp: Date
+    public let targetUserId: Int?
+}
+
+public struct Badge: Codable {
+    public let name: String
+    public let awardedAt: Date
+}
+
+public struct Challenge: Codable {
+    public let id: Int
+    public let name: String
+    public let createdBy: Int
+    public let isPrivate: Bool
+    public let targetMinutes: Int?
+    public let startDate: String?
+    public let endDate: String?
+}
+
+public struct Ad: Codable {
+    public let id: Int
+    public let text: String
+}

--- a/ios/MindfulConnect/ActivityFeedView.swift
+++ b/ios/MindfulConnect/ActivityFeedView.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+struct ActivityFeedView: View {
+    @State private var feedItems: [FeedItem] = []
+    @State private var newMessage: String = ""
+    @State private var targetUserId: Int = 0
+
+    var body: some View {
+        VStack {
+            List(feedItems, id: \.id) { item in
+                VStack(alignment: .leading) {
+                    Text(item.message)
+                        .font(.body)
+                    if let target = item.targetUserId {
+                        Text("-> User \(target)")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+            HStack {
+                TextField("Say something", text: $newMessage)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                Button("Comment") {
+                    Task {
+                        if let item = try? await MockAPIClient.shared.sendComment(newMessage, from: 1, to: targetUserId) {
+                            feedItems.insert(item, at: 0)
+                            newMessage = ""
+                        }
+                    }
+                }
+                Button("Encourage") {
+                    Task {
+                        if let item = try? await MockAPIClient.shared.sendEncouragement(newMessage, from: 1, to: targetUserId) {
+                            feedItems.insert(item, at: 0)
+                            newMessage = ""
+                        }
+                    }
+                }
+            }
+            .padding()
+        }
+        .onAppear {
+            Task {
+                if let items = try? await MockAPIClient.shared.fetchFeed() {
+                    feedItems = items
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    ActivityFeedView()
+}
+

--- a/ios/MindfulConnect/AdBannerView.swift
+++ b/ios/MindfulConnect/AdBannerView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct AdBannerView: View {
+    let isPremium: Bool
+    @State private var ad: Ad?
+
+    var body: some View {
+        Group {
+            if isPremium {
+                EmptyView()
+            } else {
+                if let ad = ad {
+                    Text(ad.text)
+                        .padding()
+                        .frame(maxWidth: .infinity)
+                        .background(Color.yellow.opacity(0.2))
+                        .cornerRadius(8)
+                } else {
+                    Color.clear
+                        .onAppear {
+                            Task {
+                                ad = try? await MockAPIClient.shared.fetchAd()
+                            }
+                        }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    AdBannerView(isPremium: false)
+}
+

--- a/ios/MindfulConnect/BadgeListView.swift
+++ b/ios/MindfulConnect/BadgeListView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct BadgeListView: View {
+    @State private var badges: [Badge] = []
+
+    var body: some View {
+        List(badges, id: \.name) { badge in
+            HStack {
+                Image(systemName: "star.fill")
+                    .foregroundColor(.yellow)
+                VStack(alignment: .leading) {
+                    Text(badge.name)
+                    Text(badge.awardedAt, style: .date)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+        .onAppear {
+            Task {
+                if let items = try? await MockAPIClient.shared.fetchBadges(for: 1) {
+                    badges = items
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    BadgeListView()
+}
+

--- a/ios/MindfulConnect/MockResponses/ad.json
+++ b/ios/MindfulConnect/MockResponses/ad.json
@@ -1,0 +1,1 @@
+{"id": 5, "text": "Upgrade to Premium for more features!"}

--- a/ios/MindfulConnect/MockResponses/badges.json
+++ b/ios/MindfulConnect/MockResponses/badges.json
@@ -1,0 +1,4 @@
+[
+    {"name": "First Session", "awardedAt": "2023-06-30T10:00:00Z"},
+    {"name": "7 Day Streak", "awardedAt": "2023-07-07T10:00:00Z"}
+]

--- a/ios/MindfulConnect/MockResponses/feed.json
+++ b/ios/MindfulConnect/MockResponses/feed.json
@@ -1,0 +1,18 @@
+[
+    {
+        "id": 1,
+        "userId": 2,
+        "itemType": "comment",
+        "message": "Great job!",
+        "timestamp": "2023-07-01T12:00:00Z",
+        "targetUserId": 1
+    },
+    {
+        "id": 2,
+        "userId": 3,
+        "itemType": "encouragement",
+        "message": "Keep it up!",
+        "timestamp": "2023-07-02T15:30:00Z",
+        "targetUserId": 1
+    }
+]

--- a/ios/MindfulConnect/MockResponses/private_challenges.json
+++ b/ios/MindfulConnect/MockResponses/private_challenges.json
@@ -1,0 +1,11 @@
+[
+    {
+        "id": 10,
+        "name": "July Challenge",
+        "createdBy": 1,
+        "isPrivate": true,
+        "targetMinutes": 600,
+        "startDate": "2023-07-01",
+        "endDate": "2023-07-31"
+    }
+]

--- a/ios/MindfulConnect/PrivateChallengesView.swift
+++ b/ios/MindfulConnect/PrivateChallengesView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct PrivateChallengesView: View {
+    let isPremium: Bool
+    @State private var challenges: [Challenge] = []
+
+    var body: some View {
+        Group {
+            if isPremium {
+                List(challenges, id: \.id) { challenge in
+                    VStack(alignment: .leading) {
+                        Text(challenge.name)
+                            .font(.headline)
+                        if let minutes = challenge.targetMinutes {
+                            Text("Target: \(minutes) min")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+                .onAppear {
+                    Task {
+                        if let items = try? await MockAPIClient.shared.fetchPrivateChallenges(for: 1) {
+                            challenges = items
+                        }
+                    }
+                }
+            } else {
+                Text("Premium required to manage private challenges.")
+                    .padding()
+            }
+        }
+    }
+}
+
+#Preview {
+    PrivateChallengesView(isPremium: true)
+}
+

--- a/ios/README.md
+++ b/ios/README.md
@@ -24,3 +24,15 @@ xcodebuild test -project MindfulConnect.xcodeproj \
 ```
 
 The command builds the app and executes the `MindfulConnectUITests` target.
+
+## Networking Layer
+
+`APIClient` and the models in `APIModels.swift` provide mocked networking
+endpoints used during development. `MockAPIClient` loads JSON from the
+`MockResponses` directory to simulate backend calls for feed interactions,
+badges, private challenges and advertisements.
+
+## Mocked Social Features
+
+`ActivityFeedView`, `BadgeListView`, `PrivateChallengesView` and `AdBannerView` provide placeholder SwiftUI interfaces for the new community functionality. They consume `MockAPIClient` to display feed comments, earned badges, premium challenges and in-app ads while real APIs are under development.
+

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,4 +1,4 @@
-from datetime import date, timeAdd commentMore actions
+from datetime import date, time
 
 from src.sessions import MeditationSession
 

--- a/web/session_form.html
+++ b/web/session_form.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Meditation Session</title>
+</head>
+<body>
+<form method="post" enctype="multipart/form-data">
+    <input type="date" name="date" required>
+    <input type="number" name="duration" placeholder="Minutes" required>
+    <input type="file" name="attachment">
+    <textarea name="notes" placeholder="Notes"></textarea>
+    <button type="submit">Submit</button>
+</form>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- create Swift models for new API endpoints
- add a mocked `APIClient` loading JSON data
- document networking layer in iOS README
- fix corrupted tests file
- add SwiftUI views for feed, badges, challenges and ads
- add missing session form template and fix backend response keys

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68404d3bd9008330965df038987e8168