### PR TITLE
Connect frontend to backend APIs for social and premium features

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -37,6 +37,11 @@ from src.api_models import (
     LocationFrequencyResponse,
     AdResponse,
 )
+from src.feed_models import (
+    CommentInput,
+    EncouragementInput,
+    FeedInteractionResponse,
+)
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("mindful")

--- a/web/frontend/src/components/FeedItemCard.tsx
+++ b/web/frontend/src/components/FeedItemCard.tsx
@@ -9,6 +9,7 @@ import {
 export interface FeedItem {
   item_id: number;
   user_id: number;
+  user_display_name?: string;
   item_type: string;
   message: string;
   comments?: FeedComment[];
@@ -41,7 +42,10 @@ export default function FeedItemCard({ item }: Props) {
 
   return (
     <li>
-      <p>{item.message}</p>
+      <p>
+        <strong>{item.user_display_name || `User ${item.user_id}`}</strong>:{' '}
+        {item.message}
+      </p>
       {comments.length > 0 && (
         <ul>
           {comments.map((c) => (

--- a/web/frontend/src/pages/MyPrivateChallenges.tsx
+++ b/web/frontend/src/pages/MyPrivateChallenges.tsx
@@ -20,8 +20,17 @@ export default function MyPrivateChallenges() {
   const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
-    getSubscription().then((sub) => setPremium(sub?.tier === "premium"));
-    getPrivateChallenges().then(setChallenges).finally(() => setLoaded(true));
+    async function load() {
+      const sub = await getSubscription();
+      const hasPremium = sub?.tier === "premium";
+      setPremium(hasPremium);
+      if (hasPremium) {
+        const list = await getPrivateChallenges();
+        setChallenges(list);
+      }
+      setLoaded(true);
+    }
+    load();
   }, []);
 
   if (!loaded) return <p>Loading...</p>;


### PR DESCRIPTION
## Summary
- import feed models in backend so comment/encourage routes work
- show user display name on feed items
- gate private challenge page behind subscription and fetch data conditionally

## Testing
- `pytest -q`
- `npm test --prefix web/frontend` *(fails: vitest not found)*
- `npm run build --prefix web/frontend` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684055fa51b08330a60a4423ea096781