### PR TITLE
Add backend lint step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+      - name: Lint backend code
+        run: |
+          pip install black
+          black --check backend src tests
       - name: Run Python tests
         run: pytest -v
 


### PR DESCRIPTION
## Summary
- add backend lint step after Python deps are installed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68405e07f1108330865c355a02a78848