### PR TITLE
Use real API for iOS private challenges

### DIFF
--- a/ios/MindfulConnect/APIModels.swift
+++ b/ios/MindfulConnect/APIModels.swift
@@ -14,14 +14,26 @@ public struct Badge: Codable {
     public let awardedAt: Date
 }
 
-public struct Challenge: Codable {
+public struct Challenge: Codable, Identifiable {
     public let id: Int
     public let name: String
-    public let createdBy: Int
-    public let isPrivate: Bool
     public let targetMinutes: Int?
     public let startDate: String?
     public let endDate: String?
+    public let createdBy: Int?
+    public let isPrivate: Bool?
+    public let description: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case targetMinutes = "target_minutes"
+        case startDate = "start_date"
+        case endDate = "end_date"
+        case createdBy = "created_by"
+        case isPrivate = "is_private"
+        case description
+    }
 }
 
 public struct Ad: Codable {
@@ -101,12 +113,22 @@ public struct StringValuePoint: Codable {
 
 public struct LocationFrequencyResponse: Codable {
     public let points: [StringValuePoint]
+}
 
 public struct ChallengeInput: Codable {
     public let name: String
     public let targetMinutes: Int
     public let startDate: String
     public let endDate: String
+    public let description: String?
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case targetMinutes = "target_minutes"
+        case startDate = "start_date"
+        case endDate = "end_date"
+        case description
+    }
 }
 
 public struct Subscription: Codable {

--- a/ios/MindfulConnect/PrivateChallengesView.swift
+++ b/ios/MindfulConnect/PrivateChallengesView.swift
@@ -3,37 +3,49 @@ import SwiftUI
 struct PrivateChallengesView: View {
     @EnvironmentObject var viewModel: AppViewModel
     @State private var challenges: [Challenge] = []
+    @State private var isPremium = false
     @State private var isLoading = false
     @State private var errorMessage: String?
+
+    @State private var showForm = false
+    @State private var editing: Challenge?
+    @State private var formName = ""
+    @State private var formMinutes = ""
+    @State private var formStart = ""
+    @State private var formEnd = ""
+
+    private let api = APIClient()
 
     var body: some View {
         Group {
             if isPremium {
-                List(challenges, id: \.id) { challenge in
-                    VStack(alignment: .leading) {
-                        Text(challenge.name)
-                            .font(.headline)
-                        if let minutes = challenge.targetMinutes {
-                            Text("Target: \(minutes) min")
-                                .font(.caption)
-                                .foregroundColor(.secondary)
+                List {
+                    ForEach(challenges) { challenge in
+                        VStack(alignment: .leading) {
+                            Text(challenge.name)
+                                .font(.headline)
+                            if let minutes = challenge.targetMinutes {
+                                Text("Target: \(minutes) min")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                        .swipeActions {
+                            Button("Edit") { edit(challenge) }
+                            Button(role: .destructive) {
+                                Task { await delete(challenge) }
+                            } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
                         }
                     }
                 }
-                .onAppear {
-                    Task {
-                        isLoading = true
-                        do {
-                            challenges = try await MockAPIClient.shared.fetchPrivateChallenges(for: 1)
-                        } catch {
-                            errorMessage = error.localizedDescription
-                        }
-                        isLoading = false
-                    }
+                .toolbar {
+                    Button("Add") { newChallenge() }
                 }
-                .overlay {
-                    if isLoading { ProgressView() }
-                }
+                .onAppear { load() }
+                .sheet(isPresented: $showForm) { formView }
+                .overlay { if isLoading { ProgressView() } }
                 .alert("Error", isPresented: Binding(get: { errorMessage != nil }, set: { _ in errorMessage = nil })) {
                     Button("OK", role: .cancel) {}
                 } message: {
@@ -44,6 +56,93 @@ struct PrivateChallengesView: View {
                     .padding()
             }
         }
+    }
+
+    private var formView: some View {
+        NavigationView {
+            Form {
+                TextField("Name", text: $formName)
+                TextField("Target Minutes", text: $formMinutes)
+                    .keyboardType(.numberPad)
+                TextField("Start Date (YYYY-MM-DD)", text: $formStart)
+                TextField("End Date (YYYY-MM-DD)", text: $formEnd)
+            }
+            .navigationTitle(editing == nil ? "New Challenge" : "Edit Challenge")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { showForm = false }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") { Task { await save() } }
+                }
+            }
+        }
+    }
+
+    private func load() {
+        guard let token = viewModel.authToken else { return }
+        Task {
+            isLoading = true
+            do {
+                let sub = try await api.getSubscription(authToken: token)
+                isPremium = sub.tier == "premium"
+                if isPremium {
+                    challenges = try await api.fetchPrivateChallenges(authToken: token)
+                }
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+            isLoading = false
+        }
+    }
+
+    private func newChallenge() {
+        editing = nil
+        formName = ""
+        formMinutes = ""
+        formStart = ""
+        formEnd = ""
+        showForm = true
+    }
+
+    private func edit(_ challenge: Challenge) {
+        editing = challenge
+        formName = challenge.name
+        formMinutes = String(challenge.targetMinutes ?? 0)
+        formStart = challenge.startDate ?? ""
+        formEnd = challenge.endDate ?? ""
+        showForm = true
+    }
+
+    private func save() async {
+        guard let token = viewModel.authToken else { return }
+        guard let minutes = Int(formMinutes) else { return }
+        let input = ChallengeInput(name: formName, targetMinutes: minutes, startDate: formStart, endDate: formEnd, description: nil)
+        isLoading = true
+        do {
+            if let editing = editing {
+                try await api.updatePrivateChallenge(id: editing.id, input: input, authToken: token)
+            } else {
+                _ = try await api.createPrivateChallenge(input, authToken: token)
+            }
+            challenges = try await api.fetchPrivateChallenges(authToken: token)
+            showForm = false
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    private func delete(_ challenge: Challenge) async {
+        guard let token = viewModel.authToken else { return }
+        isLoading = true
+        do {
+            try await api.deletePrivateChallenge(id: challenge.id, authToken: token)
+            challenges = try await api.fetchPrivateChallenges(authToken: token)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
     }
 }
 


### PR DESCRIPTION
## Summary
- update `Challenge` and `ChallengeInput` models for backend fields
- add missing brace in `APIModels.swift`
- rewrite `PrivateChallengesView` to call the real API for listing, creating, updating and deleting private challenges

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68405dceaccc8330ae5f0aa4cbb0a625