### PR TITLE
Enable live activity feed API

### DIFF
--- a/ios/MindfulConnect/APIClient.swift
+++ b/ios/MindfulConnect/APIClient.swift
@@ -153,29 +153,33 @@ public struct APIClient {
         var request = URLRequest(url: baseURL.appendingPathComponent("feed"))
         request.setValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
         let (data, _) = try await session.data(for: request)
-        return try JSONDecoder().decode([FeedItem].self, from: data)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode([FeedItem].self, from: data)
     }
 
-    public func addFeedComment(feedItemId: Int, text: String, authToken: String) async throws -> FeedItem {
+    public func addFeedComment(feedItemId: Int, text: String, authToken: String) async throws -> FeedInteractionResponse {
         let endpoint = "feed/\(feedItemId)/comment"
         var request = URLRequest(url: baseURL.appendingPathComponent(endpoint))
         request.httpMethod = "POST"
-        request.httpBody = try JSONEncoder().encode(["text": text])
+        let body = CommentInput(feedItemId: feedItemId, text: text)
+        request.httpBody = try JSONEncoder().encode(body)
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
         let (data, _) = try await session.data(for: request)
-        return try JSONDecoder().decode(FeedItem.self, from: data)
+        return try JSONDecoder().decode(FeedInteractionResponse.self, from: data)
     }
 
-    public func addFeedEncouragement(feedItemId: Int, text: String, authToken: String) async throws -> FeedItem {
+    public func addFeedEncouragement(feedItemId: Int, text: String, authToken: String) async throws -> FeedInteractionResponse {
         let endpoint = "feed/\(feedItemId)/encourage"
         var request = URLRequest(url: baseURL.appendingPathComponent(endpoint))
         request.httpMethod = "POST"
-        request.httpBody = try JSONEncoder().encode(["text": text])
+        let body = EncouragementInput(feedItemId: feedItemId, text: text)
+        request.httpBody = try JSONEncoder().encode(body)
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
         let (data, _) = try await session.data(for: request)
-        return try JSONDecoder().decode(FeedItem.self, from: data)
+        return try JSONDecoder().decode(FeedInteractionResponse.self, from: data)
     }
 
     // MARK: - Badges

--- a/ios/MindfulConnect/APIModels.swift
+++ b/ios/MindfulConnect/APIModels.swift
@@ -1,12 +1,25 @@
 import Foundation
 
-public struct FeedItem: Codable {
+public struct FeedItem: Codable, Identifiable {
     public let id: Int
     public let userId: Int
+    public let userDisplayName: String
     public let itemType: String
     public let message: String
     public let timestamp: Date
     public let targetUserId: Int?
+    public let relatedFeedItemId: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case id = "item_id"
+        case userId = "user_id"
+        case userDisplayName = "user_display_name"
+        case itemType = "item_type"
+        case message
+        case timestamp
+        case targetUserId = "target_user_id"
+        case relatedFeedItemId = "related_feed_item_id"
+    }
 }
 
 public struct Badge: Codable {
@@ -134,4 +147,34 @@ public struct ChallengeInput: Codable {
 public struct Subscription: Codable {
     public let tier: String
 
+}
+
+public struct FeedInteractionResponse: Codable {
+    public let interactionId: Int
+    public let message: String
+
+    enum CodingKeys: String, CodingKey {
+        case interactionId = "interaction_id"
+        case message
+    }
+}
+
+public struct CommentInput: Codable {
+    public let feedItemId: Int
+    public let text: String
+
+    enum CodingKeys: String, CodingKey {
+        case feedItemId = "feed_item_id"
+        case text
+    }
+}
+
+public struct EncouragementInput: Codable {
+    public let feedItemId: Int
+    public let text: String
+
+    enum CodingKeys: String, CodingKey {
+        case feedItemId = "feed_item_id"
+        case text
+    }
 }


### PR DESCRIPTION
## Summary
- connect ActivityFeedView to real backend
- add structures for commenting and encouraging feed items
- support feed endpoints in APIClient using ISO8601 dates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68405f63bedc83309a7a0f0faff6b0e3