### PR TITLE
Fix feed model imports and clarify feed models

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -50,21 +50,6 @@ from src.feed_models import (
     EncouragementInput,
     FeedInteractionResponse,
 )
-from src.feed_models import (
-    CommentInput,
-    EncouragementInput,
-    FeedInteractionResponse,
-)
-from src.feed_models import (
-    CommentInput,
-    EncouragementInput,
-    FeedInteractionResponse,
-)
-from src.feed_models import (
-    CommentInput,
-    EncouragementInput,
-    FeedInteractionResponse,
-)
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("mindful")

--- a/src/feed_models.py
+++ b/src/feed_models.py
@@ -1,13 +1,22 @@
 from pydantic import BaseModel
 
+
 class CommentInput(BaseModel):
+    """Input payload for commenting on a feed item."""
+
     feed_item_id: int
     text: str
+
 
 class EncouragementInput(BaseModel):
+    """Input payload for sending encouragement related to a feed item."""
+
     feed_item_id: int
     text: str
 
+
 class FeedInteractionResponse(BaseModel):
+    """Response returned after creating a comment or encouragement."""
+
     interaction_id: int
     message: str


### PR DESCRIPTION
## Summary
- deduplicate feed model imports in backend main entrypoint
- document feed interaction input schemas so feed_item_id field is explicit

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684065f5377c833088790a01d3a61110