### PR TITLE
Integrate live ad API for banner view

### DIFF
--- a/ios/MindfulConnect/APIClient.swift
+++ b/ios/MindfulConnect/APIClient.swift
@@ -230,6 +230,17 @@ public struct APIClient {
         _ = try await session.data(for: request)
     }
 
+    // MARK: - Ads
+    public func fetchAd() async throws -> Ad {
+        let endpoint = "ads/random"
+        let url = baseURL.appendingPathComponent(endpoint)
+        let (data, response) = try await session.data(from: url)
+        if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 204 {
+            throw URLError(.badServerResponse)
+        }
+        return try JSONDecoder().decode(Ad.self, from: data)
+    }
+
     // MARK: - Subscription
     public func getSubscription(authToken: String) async throws -> Subscription {
         var request = URLRequest(url: baseURL.appendingPathComponent("subscriptions/me"))

--- a/ios/MindfulConnect/APIModels.swift
+++ b/ios/MindfulConnect/APIModels.swift
@@ -52,6 +52,11 @@ public struct Challenge: Codable, Identifiable {
 public struct Ad: Codable {
     public let id: Int
     public let text: String
+
+    enum CodingKeys: String, CodingKey {
+        case id = "ad_id"
+        case text
+    }
 }
 public struct SocialLoginRequest: Codable {
     public let provider: String

--- a/ios/MindfulConnect/AdBannerView.swift
+++ b/ios/MindfulConnect/AdBannerView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct AdBannerView: View {
     let isPremium: Bool
     @State private var ad: Ad?
+    private let api = APIClient()
 
     var body: some View {
         Group {
@@ -19,7 +20,7 @@ struct AdBannerView: View {
                     Color.clear
                         .onAppear {
                             Task {
-                                ad = try? await MockAPIClient.shared.fetchAd()
+                                ad = try? await api.fetchAd()
                             }
                         }
                 }


### PR DESCRIPTION
## Summary
- update `Ad` model to map `ad_id`
- load ads using `APIClient` in `AdBannerView`
- implement `/ads/random` call in `APIClient`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684065fb56808330ab079fbb4c7f6cc9