### PR TITLE
Add recent activity to public profile

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -633,6 +633,7 @@ def get_user_profile(
         photo_url=profile["photo_url"],
         total_minutes=profile["total_minutes"],
         session_count=profile["session_count"],
+        recent_activity=profile["recent_activity"],
     )
 
 @app.get("/users/me/custom-meditation-types", response_model=list)

--- a/src/api_models.py
+++ b/src/api_models.py
@@ -121,3 +121,4 @@ class PublicProfileResponse(BaseModel):
     photo_url: str | None = None
     total_minutes: int
     session_count: int
+    recent_activity: List[str]

--- a/src/profiles.py
+++ b/src/profiles.py
@@ -77,6 +77,12 @@ def get_profile_with_stats(conn: sqlite3.Connection, user_id: int) -> dict:
     )
     total_minutes, session_count = cur.fetchone()
 
+    cur = conn.execute(
+        "SELECT session_type, session_date FROM sessions WHERE user_id = ? ORDER BY session_date DESC, id DESC LIMIT 5",
+        (user_id,),
+    )
+    recent_activity = [f"{r[0]} - {r[1]}" for r in cur.fetchall()]
+
     return {
         "user_id": user_id,
         "display_name": display_name,
@@ -85,4 +91,5 @@ def get_profile_with_stats(conn: sqlite3.Connection, user_id: int) -> dict:
         "is_public": bool(is_public),
         "total_minutes": total_minutes or 0,
         "session_count": session_count or 0,
+        "recent_activity": recent_activity,
     }

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -234,6 +234,10 @@ def test_public_profile_endpoint(client):
     assert data["display_name"] == "ProfileUser"
     assert data["total_minutes"] == 25
     assert data["session_count"] == 2
+    assert data["recent_activity"] == [
+        "Guided - 2023-01-02",
+        "Guided - 2023-01-01",
+    ]
 
 
 def test_update_profile_visibility_endpoint(client):

--- a/tests/test_profile_stats.py
+++ b/tests/test_profile_stats.py
@@ -24,3 +24,7 @@ def test_get_profile_with_stats():
     assert profile["display_name"] == "User"
     assert profile["total_minutes"] == 25
     assert profile["session_count"] == 2
+    assert profile["recent_activity"] == [
+        "Guided - 2023-01-02",
+        "Guided - 2023-01-01",
+    ]


### PR DESCRIPTION
## Summary
- extend `PublicProfileResponse` with `recent_activity`
- include recent sessions in `get_profile_with_stats`
- expose recent activity via `/users/{user_id}/profile`
- test recent activity in profile stats and API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68406604290c83309492d120273539ce