### PR TITLE
Add modal-based private challenge manager

### DIFF
--- a/web/frontend/e2e/my_private_challenges.cy.ts
+++ b/web/frontend/e2e/my_private_challenges.cy.ts
@@ -13,13 +13,41 @@ describe("Private challenges page", () => {
     cy.visit("/my-challenges");
     cy.wait(["@sub", "@list"]);
 
-    cy.get('input[name="name"]').type("Test Challenge");
-    cy.get('input[name="target_minutes"]').clear().type("20");
-    cy.get('input[name="start_date"]').type("2023-01-01");
-    cy.get('input[name="end_date"]').type("2023-01-10");
+    cy.contains("button", "Add Challenge").click();
+    cy.get('.modal input[name="name"]').type("Test Challenge");
+    cy.get('.modal input[name="target_minutes"]').clear().type("20");
+    cy.get('.modal input[name="start_date"]').type("2023-01-01");
+    cy.get('.modal input[name="end_date"]').type("2023-01-10");
     cy.contains("button", "Create").click();
     cy.wait("@create");
 
     cy.contains("li", "Test Challenge (20m)").should("exist");
+  });
+
+  it("edits an existing challenge", () => {
+    cy.intercept("GET", "/subscriptions/me", { tier: "premium" }).as("sub");
+    cy.intercept("GET", "/users/me/private-challenges", [
+      {
+        id: 1,
+        name: "Old Challenge",
+        target_minutes: 10,
+        start_date: "2023-01-01",
+        end_date: "2023-01-10",
+      },
+    ]).as("list");
+    cy.intercept("PUT", "/users/me/private-challenges/1", { statusCode: 200 }).as(
+      "update",
+    );
+
+    cy.visit("/my-challenges");
+    cy.wait(["@sub", "@list"]);
+
+    cy.contains("li", "Old Challenge (10m)")
+      .contains("button", "Edit")
+      .click();
+    cy.get('.modal input[name="name"]').clear().type("Updated Challenge");
+    cy.contains("button", "Update").click();
+    cy.wait("@update");
+    cy.contains("li", "Updated Challenge (10m)").should("exist");
   });
 });

--- a/web/frontend/src/App.css
+++ b/web/frontend/src/App.css
@@ -44,3 +44,21 @@ button {
     grid-template-columns: repeat(3, 1fr);
   }
 }
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.modal {
+  background: white;
+  padding: 1rem;
+  max-width: 400px;
+  width: 100%;
+}

--- a/web/frontend/src/pages/MyPrivateChallenges.tsx
+++ b/web/frontend/src/pages/MyPrivateChallenges.tsx
@@ -3,6 +3,7 @@ import {
   getPrivateChallenges,
   createPrivateChallenge,
   deletePrivateChallenge,
+  updatePrivateChallenge,
   PrivateChallenge,
   ChallengeInput,
   getSubscription,
@@ -20,6 +21,8 @@ export default function MyPrivateChallenges() {
   const [loaded, setLoaded] = useState(false);
   const [error, setError] = useState("");
   const [saving, setSaving] = useState(false);
+  const [showForm, setShowForm] = useState(false);
+  const [editing, setEditing] = useState<PrivateChallenge | null>(null);
 
   useEffect(() => {
     async function load() {
@@ -43,21 +46,28 @@ export default function MyPrivateChallenges() {
       </main>
     );
 
-  function handleChange(
-    e: React.ChangeEvent<HTMLInputElement>
-  ) {
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
     const { name, value } = e.target;
     setForm((f) => ({ ...f, [name]: name === "target_minutes" ? Number(value) : value }));
   }
 
-  async function create(e: React.FormEvent) {
+  async function save(e: React.FormEvent) {
     e.preventDefault();
     setSaving(true);
-    const c = await createPrivateChallenge(form);
-    if (c) setChallenges((prev) => [...prev, c]);
-    else setError("Failed to create challenge");
+    if (editing) {
+      await updatePrivateChallenge(editing.id, form);
+      setChallenges((prev) =>
+        prev.map((c) => (c.id === editing.id ? { ...editing, ...form } : c)),
+      );
+    } else {
+      const c = await createPrivateChallenge(form);
+      if (c) setChallenges((prev) => [...prev, c]);
+      else setError("Failed to create challenge");
+    }
     setForm({ name: "", target_minutes: 10, start_date: "", end_date: "" });
     setSaving(false);
+    setShowForm(false);
+    setEditing(null);
   }
 
   async function remove(id: number) {
@@ -69,45 +79,79 @@ export default function MyPrivateChallenges() {
     <main>
       <h1>My Private Challenges</h1>
       {error && <p style={{ color: "red" }}>{error}</p>}
-      <form onSubmit={create}>
-        <input
-          name="name"
-          value={form.name}
-          onChange={handleChange}
-          placeholder="Name"
-          required
-        />
-        <input
-          type="number"
-          name="target_minutes"
-          value={form.target_minutes}
-          onChange={handleChange}
-          required
-        />
-        <input
-          type="date"
-          name="start_date"
-          value={form.start_date}
-          onChange={handleChange}
-          required
-        />
-        <input
-          type="date"
-          name="end_date"
-          value={form.end_date}
-          onChange={handleChange}
-          required
-        />
-        <button type="submit" disabled={saving}>Create</button>
-      </form>
+      <button
+        onClick={() => {
+          setEditing(null);
+          setForm({ name: "", target_minutes: 10, start_date: "", end_date: "" });
+          setShowForm(true);
+        }}
+      >
+        Add Challenge
+      </button>
       <ul>
         {challenges.map((c) => (
           <li key={c.id}>
             {c.name} ({c.target_minutes}m)
+            <button
+              onClick={() => {
+                setEditing(c);
+                setForm({
+                  name: c.name,
+                  target_minutes: c.target_minutes,
+                  start_date: c.start_date,
+                  end_date: c.end_date,
+                });
+                setShowForm(true);
+              }}
+            >
+              Edit
+            </button>
             <button onClick={() => remove(c.id)}>Delete</button>
           </li>
         ))}
       </ul>
+      {showForm && (
+        <div className="modal-overlay">
+          <div className="modal">
+            <form onSubmit={save}>
+              <input
+                name="name"
+                value={form.name}
+                onChange={handleChange}
+                placeholder="Name"
+                required
+              />
+              <input
+                type="number"
+                name="target_minutes"
+                value={form.target_minutes}
+                onChange={handleChange}
+                required
+              />
+              <input
+                type="date"
+                name="start_date"
+                value={form.start_date}
+                onChange={handleChange}
+                required
+              />
+              <input
+                type="date"
+                name="end_date"
+                value={form.end_date}
+                onChange={handleChange}
+                required
+              />
+              <button type="submit" disabled={saving}>
+                {editing ? "Update" : "Create"}
+              </button>
+              <button type="button" onClick={() => setShowForm(false)}>
+                Cancel
+              </button>
+            </form>
+          </div>
+        </div>
+      )}
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- enable editing private challenges via modal form
- style modal overlay and container
- update E2E tests for new UI and editing flow

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run e2e` *(fails: cypress not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840679355e0833096a71856e9e6a5a4