### PR TITLE
Improve responsiveness on key web pages

### DIFF
--- a/web/frontend/src/App.css
+++ b/web/frontend/src/App.css
@@ -62,3 +62,48 @@ button {
   max-width: 400px;
   width: 100%;
 }
+
+/* Responsive refinements */
+@media (max-width: 600px) {
+  main {
+    padding: 0.5rem;
+  }
+  h1 {
+    font-size: 1.5rem;
+  }
+}
+
+.feed-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.feed-item {
+  border: 1px solid #ddd;
+  padding: 0.75rem;
+  border-radius: 4px;
+  margin-bottom: 0.75rem;
+}
+
+@media (min-width: 600px) {
+  .feed-item {
+    padding: 1rem;
+  }
+}
+
+.form-row {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+@media (min-width: 600px) {
+  .form-row {
+    flex-direction: row;
+  }
+}
+
+.form-row label {
+  flex: 1;
+}

--- a/web/frontend/src/components/FeedItemCard.tsx
+++ b/web/frontend/src/components/FeedItemCard.tsx
@@ -41,7 +41,7 @@ export default function FeedItemCard({ item }: Props) {
   }
 
   return (
-    <li>
+    <li className="feed-item">
       <p>
         <strong>{item.user_display_name || `User ${item.user_id}`}</strong>:{' '}
         {item.message}

--- a/web/frontend/src/pages/ActivityFeed.tsx
+++ b/web/frontend/src/pages/ActivityFeed.tsx
@@ -23,7 +23,7 @@ export default function ActivityFeedPage() {
   return (
     <main>
       <h1>Activity Feed</h1>
-      <ul>
+      <ul className="feed-list">
         {items.map((i) => (
           <FeedItemCard key={i.item_id} item={i} />
         ))}

--- a/web/frontend/src/pages/SessionForm.tsx
+++ b/web/frontend/src/pages/SessionForm.tsx
@@ -130,28 +130,30 @@ export default function SessionForm() {
           Notes
           <textarea name="notes" value={form.notes} onChange={handleChange} />
         </label>
-        <label>
-          Mood Before
-          <input
-            type="number"
-            name="moodBefore"
-            value={form.moodBefore}
-            onChange={handleChange}
-            min="1"
-            max="10"
-          />
-        </label>
-        <label>
-          Mood After
-          <input
-            type="number"
-            name="moodAfter"
-            value={form.moodAfter}
-            onChange={handleChange}
-            min="1"
-            max="10"
-          />
-        </label>
+        <div className="form-row">
+          <label>
+            Mood Before
+            <input
+              type="number"
+              name="moodBefore"
+              value={form.moodBefore}
+              onChange={handleChange}
+              min="1"
+              max="10"
+            />
+          </label>
+          <label>
+            Mood After
+            <input
+              type="number"
+              name="moodAfter"
+              value={form.moodAfter}
+              onChange={handleChange}
+              min="1"
+              max="10"
+            />
+          </label>
+        </div>
         <label>
           Photo
           <input type="file" onChange={handleFileChange} />


### PR DESCRIPTION
## Summary
- enhance feed item layout and style
- adjust dashboard feed list structure
- tweak session form layout for small screens
- add responsive classes and media queries

## Testing
- `npm run test` *(fails: vitest not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6840693a963c8330b0a1e3e08576f266