### PR TITLE
Adjust skip condition for frontend tests

### DIFF
--- a/tests/test_frontend_integration.py
+++ b/tests/test_frontend_integration.py
@@ -1,13 +1,16 @@
 import os
 import subprocess
+import shutil
 from pathlib import Path
 import pytest
 
 frontend_dir = Path(__file__).resolve().parents[1] / "web" / "frontend"
+skip_reason = "node modules or npm missing"
 
 
 @pytest.mark.skipif(
-    not (frontend_dir / "node_modules").exists(), reason="node modules not installed"
+    not (frontend_dir / "node_modules").exists() or shutil.which("npm") is None,
+    reason=skip_reason,
 )
 def test_frontend_tests():
     result = subprocess.run(["npm", "test", "--", "--run"], cwd=frontend_dir)


### PR DESCRIPTION
## Summary
- detect npm via `shutil.which`
- skip frontend integration tests when node modules or npm are missing

## Testing
- `pytest -k test_frontend_integration -q`

------
https://chatgpt.com/codex/tasks/task_e_68407d70968883309c11e8bf03013131