### PR TITLE
Add CORS middleware to backend

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -5,6 +5,7 @@ import sqlite3
 from datetime import time, date
 from fastapi import FastAPI, HTTPException, Request, Depends, Header, Response
 from fastapi.staticfiles import StaticFiles
+from fastapi.middleware.cors import CORSMiddleware
 from jose import JWTError, jwt as jose_jwt
 from pathlib import Path
 from uuid import uuid4
@@ -58,6 +59,21 @@ SECRET_KEY = os.getenv("JWT_SECRET", "super-secret")  # Changed default for clar
 ALGORITHM = "HS256"
 
 app = FastAPI()
+
+# Allow cross-origin requests from the frontend during development
+origins = [
+    "http://localhost",
+    "http://localhost:5173",
+    "http://127.0.0.1:5173",
+]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 UPLOAD_DIR = Path("uploads")
 UPLOAD_DIR.mkdir(exist_ok=True)


### PR DESCRIPTION
## Summary
- allow cross-origin requests from the dev frontend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68408991c9dc8330a8b50dc3ad54ae8c